### PR TITLE
Adding functionality to PixelflowResult to output a .csv file

### DIFF
--- a/src/pixelflow/core.py
+++ b/src/pixelflow/core.py
@@ -42,8 +42,8 @@ def pixelflow_custom(
 
 
 @dataclasses.dataclass
-class PixelflowResult:
-    """Result container with addional `reduce` functionality."""
+class PixelflowResult():
+    """Result container with additional `reduce` functionality."""
     features: pd.DataFrame 
 
     def count(self) -> int:
@@ -58,6 +58,10 @@ class PixelflowResult:
     
     def _repr_html_(self) -> str:
         return self.features.to_html()
+    
+    def to_csv(self, path: str, **kwargs) -> None:
+        self.features.to_csv(path, **kwargs)
+    
         
 
 def pixelflow(

--- a/src/pixelflow/core.py
+++ b/src/pixelflow/core.py
@@ -42,7 +42,7 @@ def pixelflow_custom(
 
 
 @dataclasses.dataclass
-class PixelflowResult():
+class PixelflowResult:
     """Result container with additional `reduce` functionality."""
     features: pd.DataFrame 
 
@@ -59,7 +59,7 @@ class PixelflowResult():
     def _repr_html_(self) -> str:
         return self.features.to_html()
     
-    def to_csv(self, path: str, **kwargs) -> None:
+    def to_csv(self, path: os.PathLike, **kwargs) -> None:
         self.features.to_csv(path, **kwargs)
     
         


### PR DESCRIPTION
Addressing issue #7, by adding the ability to output a .csv file by just calling `.to_csv` on the output of the pixelflow function, rather than having to call `.features.to_csv`. 

This function is based on the pandas `to_csv` function, so should behave in the same way (including taking in the same arguments such as header and index).