### PR TITLE
Outputting the bounding boxes in the simulated image

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from skimage.measure import label
+from skimage.measure import label, regionprops
 
 from ._utils import simulate_image
 
@@ -13,5 +13,7 @@ def simulated_dataset(request):
     num_blobs = 5
     img, coords = simulate_image(size=size, num_blobs=num_blobs)
     mask = label(img > 2.3)
+    props = regionprops(mask)
+    bbox = [prop.bbox for prop in props]
     assert np.max(mask) == num_blobs
-    return mask, img, coords
+    return mask, img, coords, bbox

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,11 +1,11 @@
-import pixelflow
 import pytest
+import pixelflow
 
 
 @pytest.mark.parametrize("simulated_dataset", (2, 3), indirect=True)
 def test_core_count(simulated_dataset):
     """Test counting using a simulated 2D or 3D image."""
-    mask, img, coords = simulated_dataset
+    mask, img, coords, bbox = simulated_dataset
 
     num_blobs = coords.shape[0]
     assert img.ndim == coords.shape[-1]


### PR DESCRIPTION
Addressing #27, the tests now output the bounding boxes (though currently they aren't used subsequently 