### PR TITLE
Adding a lower limit to the scikit-image dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pixelflow"
 authors = [
-  {name = "Alan R. Lowe", email = "alowe@turing.ac.uk"}
+  {name = "Alan R. Lowe", email = "alowe@turing.ac.uk"},
+  {name = "Isabel S. Fenton", email = "ifenton@turing.ac.uk"},
 ]
 description = "Pixelflow"
 readme = "README.md"
@@ -20,7 +21,7 @@ dependencies = [
   "numpy",
   "pandas",
   "porespy",
-  "scikit-image"
+  "scikit-image>=0.20.0" # to include the spacing argument in regionprops
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pixelflow"
 authors = [
   {name = "Alan R. Lowe", email = "alowe@turing.ac.uk"},
-  {name = "Isabel S. Fenton", email = "ifenton@turing.ac.uk"},
+  {name = "Isabel S. Fenton", email = "ifenton@turing.ac.uk"}
 ]
 description = "Pixelflow"
 readme = "README.md"


### PR DESCRIPTION
Scikit-image below 0.20.0 doesn't include the spacing argument in regionprops which pixelflow requires. 