### PR TITLE
README fix and expanded mask types

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ pip install git+https://github.com/alan-turing-institute/pixelflow.git
 
 ``` python
 from pixelflow import pixelflow, pixelflow_custom
+import numpy.typing as npt
 
 @pixelflow_custom
 def custom_func(x: npt.NDArray, y: npt.NDArray) -> float:
@@ -29,7 +30,7 @@ pixelflow(
     mask,
     img,
     features=('label', 'bbox', 'centroid', 'area', 'major_axis_length', 'orientation', 'image_intensity'),
-    custom=(custom_func,)
+    custom=(custom_func,),
     dim_labels="YX",
     labelled=True
 )

--- a/src/pixelflow/core.py
+++ b/src/pixelflow/core.py
@@ -180,7 +180,6 @@ def pixelflow(
     """
     # cast mask to int to remove type ambiguity (e.g. bool, float)
     mask = mask.astype('int')
-    print(mask)
 
     # check if mask contains any objects
     if mask.max() - mask.min() == 0:

--- a/src/pixelflow/core.py
+++ b/src/pixelflow/core.py
@@ -198,6 +198,9 @@ def pixelflow(
     if len(dim_labels) != mask.ndim:
         raise ValueError("dim_labels doesn't match mask dimensions")
 
+    # cast mask to int to remove type ambiguity (e.g. bool, float)
+    mask = mask.astype('int')
+
     # check if image is labelled
     mask = mask if labelled else label(mask)
 

--- a/src/pixelflow/core.py
+++ b/src/pixelflow/core.py
@@ -178,6 +178,9 @@ def pixelflow(
         * Image padding to take care of edges
         * Supplying different image channels to different functions
     """
+    # cast mask to int to remove type ambiguity (e.g. bool, float)
+    mask = mask.astype('int')
+    print(mask)
 
     # check if mask contains any objects
     if mask.max() - mask.min() == 0:
@@ -197,9 +200,6 @@ def pixelflow(
     # check dim_labels matches mask.ndim
     if len(dim_labels) != mask.ndim:
         raise ValueError("dim_labels doesn't match mask dimensions")
-
-    # cast mask to int to remove type ambiguity (e.g. bool, float)
-    mask = mask.astype('int')
 
     # check if image is labelled
     mask = mask if labelled else label(mask)


### PR DESCRIPTION
1. Syntax and import (numpy.typing) fixes to README.
2. Added line to make boolean and float masks cast to int.
3. Alternatively, floats could be binarised or the labels generalised using np.unique followed by reassignment but this may be opaque as to how the float -> label mapping is implemented. Perhaps an error should be thrown specifically for non-int/bool masks. Boolean masks seem justified given the abundance of thresholding methods that use it (e.g. in skimage). 